### PR TITLE
feat: complete Tab Bar with busy indicator, workspace isolation, keyboard nav

### DIFF
--- a/app_root/cascade-panel.html
+++ b/app_root/cascade-panel.html
@@ -115,6 +115,14 @@
               summaries = ms.summaries;
               break;
             }
+            // useRef 模式: { current: { [uuid]: ... } }
+            if (ms.current && typeof ms.current === 'object' && !Array.isArray(ms.current)) {
+              const ck = Object.keys(ms.current);
+              if (ck.length > 0 && /^[0-9a-f]{8}-/.test(ck[0])) {
+                summaries = ms.current;
+                break;
+              }
+            }
             // Check if keys look like UUIDs
             const keys = Object.keys(ms);
             if (keys.length > 0 && /^[0-9a-f]{8}-/.test(keys[0])) {
@@ -126,12 +134,19 @@
           sIdx++;
         }
 
-        // Build conversation list
+        // Build conversation list — 兼容多种字段命名
         const conversations = cascadeIds.map(id => {
-          const info = summaries[id] || {};
+          const raw = summaries[id];
+          let info = {};
+          if (typeof raw === 'string') {
+            // 直接以字符串存储 summary
+            info = { summary: raw };
+          } else if (raw && typeof raw === 'object') {
+            info = raw;
+          }
           return {
             cascadeId: id,
-            summary: info.summary || '',
+            summary: info.summary || info.name || info.title || info.displayName || '',
             lastModifiedTime: info.lastModifiedTime || '',
             status: info.status || '',
             stepCount: info.stepCount || 0
@@ -182,13 +197,283 @@
         }
       }
 
+      // Find conversation title from multiple sources
+      function findConversationTitle(cascadeId) {
+        if (!cascadeId) return null;
+
+        // Source 1: conversation list cache
+        try {
+          const convos = findConversationList();
+          const match = convos.find(c => c.cascadeId === cascadeId);
+          if (match && match.summary) return match.summary;
+        } catch (e) { /* ignore */ }
+
+        // Source 2: cascade context state — 检查多种字段名
+        try {
+          const ctx = findCascadeContext();
+          if (ctx && ctx.state) {
+            const cs = ctx.state.cascadeState || {};
+            if (cs.cascadeId === cascadeId) {
+              const t = cs.summary || cs.title || cs.name || cs.displayName;
+              if (t) return t;
+            }
+            // 检查 state 中是否有 conversations map（多种可能的字段名）
+            const convMaps = [ctx.state.conversations, ctx.state.cascadeConversations, ctx.state.conversationMap];
+            for (const convMap of convMaps) {
+              if (convMap && typeof convMap === 'object') {
+                const c = convMap[cascadeId];
+                if (c) {
+                  const t = typeof c === 'string' ? c : (c.summary || c.title || c.name || c.displayName);
+                  if (t) return t;
+                }
+              }
+            }
+          }
+        } catch (e) { /* ignore */ }
+
+        // Source 3: scan fiber tree for props/state containing this cascadeId
+        try {
+          const container = getReactContainer();
+          if (container) {
+            const visited = new WeakSet();
+            const queue = [container];
+            let count = 0;
+            while (queue.length > 0 && count < MAX_FIBER_DEPTH) {
+              const f = queue.shift();
+              if (!f || visited.has(f)) continue;
+              visited.add(f);
+              count++;
+
+              // 检查 props 中的 cascadeId + summary/title/name
+              const p = f.memoizedProps;
+              if (p && typeof p === 'object') {
+                if (p.cascadeId === cascadeId) {
+                  const t = p.summary || p.title || p.name || p.displayName;
+                  if (t) return t;
+                }
+                // 检查 props.conversation 或 props.data 中是否有标题
+                const nested = p.conversation || p.data || p.item;
+                if (nested && typeof nested === 'object' && nested.cascadeId === cascadeId) {
+                  const t = nested.summary || nested.title || nested.name;
+                  if (t) return t;
+                }
+              }
+
+              // Source 4: 检查 memoizedState 链中是否有 cascadeId 关联的标题
+              let st = f.memoizedState;
+              let si = 0;
+              while (st && si < 8) {
+                const ms = st.memoizedState;
+                if (ms && typeof ms === 'object' && !Array.isArray(ms)) {
+                  // 直接检查是否有 cascadeId 作为 key
+                  const entry = ms[cascadeId] || (ms.current && ms.current[cascadeId]);
+                  if (entry) {
+                    const t = typeof entry === 'string' ? entry : (entry.summary || entry.title || entry.name || entry.displayName);
+                    if (t) return t;
+                  }
+                }
+                st = st.next;
+                si++;
+              }
+
+              if (f.child) queue.push(f.child);
+              if (f.sibling) queue.push(f.sibling);
+            }
+          }
+        } catch (e) { /* ignore */ }
+
+        // Source 5: DOM 标题提取 — 仅对当前活跃对话有效
+        // Cascade 面板顶部有一个 <p> 元素显示当前对话标题
+        try {
+          if (_currentCascadeId === cascadeId || getCurrentCascadeId() === cascadeId) {
+            const titleEl = document.querySelector('p[class*="text-ellipsis"][class*="whitespace-nowrap"]');
+            if (titleEl) {
+              const text = (titleEl.textContent || '').trim();
+              if (text && text.length > 0 && text.length < 100) return text;
+            }
+          }
+        } catch (e) { /* ignore */ }
+
+        return null;
+      }
+
+      // Detect busy (generating) conversations
+      // 'active' 和 'pending' 已移除：'active' 匹配所有打开的对话，'pending' 匹配等待中的对话，均非生成状态
+      const BUSY_STATUSES = ['in_progress', 'generating', 'streaming', 'running', 'processing'];
+      // 数字状态映射：需通过 diagnoseBusy() 在生成中捕获实际忙碌值后填入
+      // CDP 调试确认 1 = idle，其他值待确认
+      const NUMERIC_BUSY_STATUSES = new Set();
+      const _discoveredStatuses = new Set();
+
+      function getBusyConversations() {
+        const busyIds = new Set();
+        let _layer1HasData = false;
+
+        // Layer 1: Check conversation list status fields
+        try {
+          const convos = findConversationList();
+          if (convos.length > 0) _layer1HasData = true;
+          for (const c of convos) {
+            if (c.status != null) {
+              // 记录发现的状态值（含类型信息）
+              const statusKey = typeof c.status + ':' + c.status;
+              if (!_discoveredStatuses.has(statusKey)) {
+                _discoveredStatuses.add(statusKey);
+                const logLevel = localStorage.getItem('ag-better-log-level');
+                if (logLevel === 'debug') {
+                  console.log('[AG-Bridge] Discovered status value:', JSON.stringify(c.status), 'type:', typeof c.status);
+                }
+              }
+              // 数字类型直接检查
+              if (typeof c.status === 'number' && NUMERIC_BUSY_STATUSES.has(c.status)) {
+                busyIds.add(c.cascadeId);
+                continue;
+              }
+              // 字符串类型
+              const s = String(c.status).toLowerCase();
+              if (BUSY_STATUSES.includes(s)) {
+                busyIds.add(c.cascadeId);
+              }
+            }
+          }
+        } catch (e) { /* ignore */ }
+
+        // Layer 2: Check cascade context state
+        // CDP 调试确认：isGenerating/isStreaming 在此 Cascade 版本中始终为 undefined
+        // 实际忙碌指标：st.isRunning (top-level bool) 和 cs.executorLoopStatus (1=idle, 2+=busy)
+        try {
+          const ctx = findCascadeContext();
+          if (ctx && ctx.state) {
+            const st = ctx.state;
+            const cs = st.cascadeState || {};
+            const cascadeId = cs.cascadeId;
+            if (cascadeId) {
+              const isBusy = (st.isRunning === true)
+                || (st.isGenerating === true) || (st.isStreaming === true)
+                || (cs.isGenerating === true) || (cs.isStreaming === true)
+                || (typeof cs.executorLoopStatus === 'number' && cs.executorLoopStatus > 1);
+              if (isBusy) {
+                busyIds.add(cascadeId);
+                const logLevel = localStorage.getItem('ag-better-log-level');
+                if (logLevel === 'debug') {
+                  console.log('[AG-Bridge] Layer2 busy:', cascadeId.substring(0, 8),
+                    'isRunning:', st.isRunning, 'execLoop:', cs.executorLoopStatus,
+                    'isGen:', st.isGenerating, cs.isGenerating,
+                    'isStr:', st.isStreaming, cs.isStreaming);
+                }
+              }
+            }
+          }
+        } catch (e) { /* ignore */ }
+
+        // Layer 3: DOM-based — 仅作为最后防线，且不覆盖 Layer 1 的判断
+        // 只在 Layer 1 无数据时启用，且只匹配高置信度的 stop/cancel 按钮
+        try {
+          const currentId = getCurrentCascadeId();
+          // 仅当 Layer 1 没有该对话的数据时才用 DOM 检测
+          // 如果 Layer 1 已经报告了状态（包括 idle），信任 Layer 1
+          if (currentId && !busyIds.has(currentId) && !_layer1HasData) {
+            const selectors = [
+              // 仅保留 stop/cancel 按钮 — 唯一可靠的生成中 DOM 指标
+              // 这些按钮只在 AI 生成期间存在，完成后立即从 DOM 移除
+              '[data-testid="stop-button"]',
+              'button[aria-label="Stop"]',
+              'button[aria-label="Cancel"]',
+              '.stop-button',
+              '.codicon-debug-stop'
+              // 已移除：.animate-pulse, [class*="streaming"], [class*="generating"],
+              // [class*="typing"], .in-progress-checkbox — 这些匹配 Cascade 常驻 UI 元素，
+              // 导致空闲对话被误判为忙碌
+            ];
+            const searchRoot = document.getElementById('react-app') || document.body;
+            const found = searchRoot.querySelector(selectors.join(','));
+            if (found && !found.closest('#ag-tab-bar') && found.offsetHeight > 0) {
+              busyIds.add(currentId);
+              if (!_discoveredStatuses.has('__dom_detected__')) {
+                const logLevel = localStorage.getItem('ag-better-log-level');
+                if (logLevel === 'debug') {
+                  console.log('[AG-Bridge] DOM busy detected via:', found.tagName, found.className.substring(0, 80));
+                }
+                _discoveredStatuses.add('__dom_detected__');
+              }
+            }
+          }
+        } catch (e) { /* ignore */ }
+
+        return busyIds;
+      }
+
+      // 获取工作区标识，用于隔离不同项目的 Tab 数据
+      function getWorkspaceId() {
+        try {
+          const parentTitle = window.parent.document.title || '';
+          // 格式: "WorkspaceName — filename" 或 "WorkspaceName"
+          const dashIdx = parentTitle.indexOf(' \u2014 ');
+          const ws = dashIdx > 0 ? parentTitle.substring(0, dashIdx).trim() : parentTitle.trim();
+          if (ws.length > 0) return ws;
+        } catch (e) { /* cross-origin or no parent */ }
+        return 'default';
+      }
+
+      // 诊断函数：输出三层忙碌检测的实时状态
+      function diagnoseBusy() {
+        const result = { layers: {} };
+        try {
+          const convos = findConversationList();
+          result.layers.layer1 = convos.map(function(c) {
+            return {
+              id: c.cascadeId ? c.cascadeId.substring(0, 8) : null,
+              status: c.status,
+              statusType: typeof c.status
+            };
+          });
+        } catch (e) { result.layers.layer1 = { error: e.message }; }
+        try {
+          const ctx = findCascadeContext();
+          if (ctx && ctx.state) {
+            var cs = ctx.state.cascadeState || {};
+            var st = ctx.state;
+            result.layers.layer2 = {
+              cascadeId: cs.cascadeId,
+              status: cs.status,
+              executorLoopStatus: cs.executorLoopStatus,
+              isRunning: st.isRunning,
+              isGenerating: st.isGenerating || cs.isGenerating,
+              isStreaming: st.isStreaming || cs.isStreaming,
+              wouldTrigger: (st.isRunning === true)
+                || (st.isGenerating === true) || (st.isStreaming === true)
+                || (cs.isGenerating === true) || (cs.isStreaming === true)
+                || (typeof cs.executorLoopStatus === 'number' && cs.executorLoopStatus > 1)
+            };
+          }
+        } catch (e) { result.layers.layer2 = { error: e.message }; }
+        try {
+          var selectors = [
+            '[data-testid="stop-button"]', 'button[aria-label="Stop"]',
+            'button[aria-label="Cancel"]', '.stop-button', '.codicon-debug-stop'
+          ];
+          var searchRoot = document.getElementById('react-app') || document.body;
+          var found = searchRoot.querySelector(selectors.join(','));
+          result.layers.layer3 = {
+            found: !!found,
+            element: found ? found.tagName + '.' + found.className.substring(0, 60) : null
+          };
+        } catch (e) { result.layers.layer3 = { error: e.message }; }
+        result.busyIds = Array.from(getBusyConversations());
+        return result;
+      }
+
       // Expose bridge API on window for TabManager to use
       window._agBridge = {
         findCascadeContext: findCascadeContext,
         findConversationList: findConversationList,
+        findConversationTitle: findConversationTitle,
         getCurrentCascadeId: getCurrentCascadeId,
         switchConversation: switchConversation,
         startNewConversation: startNewConversation,
+        getBusyConversations: getBusyConversations,
+        getWorkspaceId: getWorkspaceId,
+        diagnoseBusy: diagnoseBusy,
         isReady: function() { return !!findCascadeContext(); }
       };
 
@@ -224,8 +509,8 @@
       top: 0;
       left: 0;
       right: 0;
-      background: var(--bg-modal);
-      border-bottom: 1px solid var(--border-color);
+      background: #e8e8e8;
+      border-bottom: 1px solid #ccc;
       display: flex;
       align-items: center;
       z-index: 1000;
@@ -241,15 +526,44 @@
       justify-content: center;
       background: transparent;
       border: none;
-      color: var(--text-sub);
+      color: #555;
       cursor: pointer;
       border-radius: 4px;
       margin-right: 4px;
       transition: all 0.2s;
     }
     .ag-add-tab-btn:hover {
-      background: rgba(255, 255, 255, 0.1);
-      color: var(--text-main);
+      background: rgba(0, 0, 0, 0.08);
+      color: #222;
+    }
+    /* Tab 计数器：显示在 + 按钮右侧 */
+    .ag-tab-counter {
+      flex: 0 0 auto;
+      font-size: 11px;
+      color: #888;
+      margin-right: 4px;
+      user-select: none;
+      white-space: nowrap;
+    }
+    /* Tab 栏提示 toast（固定定位在 tab bar 下方） */
+    .ag-tab-toast {
+      position: fixed;
+      left: 50%;
+      top: 40px;
+      transform: translateX(-50%);
+      background: rgba(0, 0, 0, 0.78);
+      color: #fff;
+      font-size: 12px;
+      padding: 4px 12px;
+      border-radius: 4px;
+      white-space: nowrap;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.25s;
+      z-index: 1001;
+    }
+    .ag-tab-toast.ag-toast-visible {
+      opacity: 1;
     }
     .ag-tabs-scroll {
       flex: 1;
@@ -261,16 +575,17 @@
     }
     .ag-tabs-scroll::-webkit-scrollbar { display: none; }
     .ag-tab-item {
+      position: relative;
       flex: 0 0 auto;
       height: 28px;
       padding: 0 12px;
       display: flex;
       align-items: center;
       gap: 8px;
-      background: rgba(255, 255, 255, 0.05);
-      border: 1px solid transparent;
+      background: #d5d5d5;
+      border: 1px solid #bbb;
       border-radius: 4px;
-      color: var(--text-sub);
+      color: #444;
       font-size: 11px;
       cursor: pointer;
       white-space: nowrap;
@@ -278,13 +593,13 @@
       transition: all 0.2s;
     }
     .ag-tab-item:hover {
-      background: rgba(255, 255, 255, 0.1);
-      color: var(--text-main);
+      background: #c8c8c8;
+      color: #111;
     }
     .ag-tab-item.active {
-      background: rgba(102, 126, 234, 0.12);
-      border-color: rgba(102, 126, 234, 0.4);
-      color: var(--accent-color);
+      background: #f0f0f0;
+      border-color: #667eea;
+      color: #111;
     }
     .ag-tab-item span {
       overflow: hidden;
@@ -292,13 +607,45 @@
     }
     .ag-tab-close {
       font-size: 14px;
-      opacity: 0.4;
+      color: #666;
+      opacity: 0.6;
       margin-right: -4px;
       transition: opacity 0.2s;
     }
-    .ag-tab-close:hover { opacity: 1; }
+    .ag-tab-close:hover { opacity: 1; color: #222; }
     .ag-tab-item[data-stale] { opacity: 0.5; }
-    .ag-tab-item[data-stale] span:first-child { font-style: italic; color: #888; }
+    .ag-tab-item[data-stale] span:first-child { font-style: italic; color: #999; }
+    .ag-tab-dot {
+      display: inline-block;
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: #999;
+      flex-shrink: 0;
+    }
+    .ag-tab-dot.active-dot {
+      background: #4ADE80;
+    }
+    /* Scroll arrows for tab overflow */
+    .ag-scroll-btn {
+      flex: 0 0 24px;
+      height: 28px;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      background: linear-gradient(to right, #e0e0e0, #e8e8e8);
+      border: none;
+      color: #555;
+      cursor: pointer;
+      font-size: 14px;
+      padding: 0;
+      transition: color 0.15s, background 0.15s;
+      user-select: none;
+    }
+    .ag-scroll-btn:last-child { background: linear-gradient(to left, #e0e0e0, #e8e8e8); }
+    .ag-scroll-btn:hover { color: #111; background: #d0d0d0; }
+    .ag-scroll-btn.visible { display: flex; }
+    .ag-scroll-btn.at-edge { opacity: 0.3; cursor: default; }
     @keyframes ag-tab-shake {
       0%, 100% { transform: translateX(0); }
       20% { transform: translateX(-3px); }
@@ -307,6 +654,17 @@
       80% { transform: translateX(2px); }
     }
     .ag-tab-item.shake { animation: ag-tab-shake 0.4s ease-in-out; }
+    .ag-tab-rename-input {
+      border: none;
+      background: transparent;
+      font: inherit;
+      color: inherit;
+      padding: 0;
+      margin: 0;
+      outline: none;
+      min-width: 40px;
+      max-width: 140px;
+    }
     body.ag-tab-bar-active .react-app-container {
       margin-top: 36px;
       height: calc(100% - 36px) !important;
@@ -2749,7 +3107,13 @@
     }
 
     /* ===== HistoryTabManager ===== */
-    const TAB_STORAGE_KEY = 'ag-better-tab-state';
+    const TAB_STORAGE_KEY_GLOBAL = 'ag-better-tabs';
+    const TAB_STORAGE_KEY_OLD = 'ag-better-tab-state';
+    function getTabStorageKey() {
+      const wsId = (window._agBridge && window._agBridge.getWorkspaceId)
+        ? window._agBridge.getWorkspaceId() : 'default';
+      return 'ag-better-tabs-' + wsId;
+    }
     const LOG_LEVELS = { error: 0, warn: 1, info: 2, debug: 3 };
 
     class HistoryTabManager {
@@ -2783,6 +3147,7 @@
       init() {
         this._createTabBarDOM();
         this._loadPersistedTabs();
+        this._updateCounter(); // 初始化计数器
         this._waitForBridge();
         document.body.classList.add('ag-tab-bar-active');
         this._log('info', 'Tab bar initialized');
@@ -2800,12 +3165,113 @@
         addBtn.addEventListener('click', () => this._onAddTab());
         this._container.appendChild(addBtn);
 
+        // Tab 计数器（+ 按钮右侧）
+        this._counterEl = document.createElement('span');
+        this._counterEl.className = 'ag-tab-counter';
+        this._container.appendChild(this._counterEl);
+
+        // Left scroll arrow
+        this._scrollLeftBtn = document.createElement('button');
+        this._scrollLeftBtn.className = 'ag-scroll-btn';
+        this._scrollLeftBtn.textContent = '\u25C0';
+        this._scrollLeftBtn.addEventListener('click', () => {
+          this._scrollArea.scrollBy({ left: -120, behavior: 'smooth' });
+        });
+        this._container.appendChild(this._scrollLeftBtn);
+
         // Scroll area for tabs
         this._scrollArea = document.createElement('div');
         this._scrollArea.className = 'ag-tabs-scroll';
+        this._scrollArea.addEventListener('scroll', () => this._updateScrollArrows());
         this._container.appendChild(this._scrollArea);
 
+        // Right scroll arrow
+        this._scrollRightBtn = document.createElement('button');
+        this._scrollRightBtn.className = 'ag-scroll-btn';
+        this._scrollRightBtn.textContent = '\u25B6';
+        this._scrollRightBtn.addEventListener('click', () => {
+          this._scrollArea.scrollBy({ left: 120, behavior: 'smooth' });
+        });
+        this._container.appendChild(this._scrollRightBtn);
+
         document.body.prepend(this._container);
+
+        // Toast 提示元素（放在 body 上避免被 container overflow:hidden 裁切）
+        this._toastEl = document.createElement('div');
+        this._toastEl.className = 'ag-tab-toast';
+        document.body.appendChild(this._toastEl);
+
+        // 使 tab bar 容器可聚焦，用于键盘导航
+        this._container.setAttribute('tabindex', '0');
+        // 键盘导航事件（仅在 tab bar 聚焦时生效）
+        this._keydownHandler = (e) => this._handleKeydown(e);
+        this._container.addEventListener('keydown', this._keydownHandler);
+
+        // Update arrows on window resize (panel width changes)
+        this._resizeHandler = () => this._updateScrollArrows();
+        window.addEventListener('resize', this._resizeHandler);
+      }
+
+      _updateScrollArrows() {
+        if (!this._scrollArea || !this._scrollLeftBtn || !this._scrollRightBtn) return;
+        // Use setTimeout to let layout settle after DOM changes and smooth scroll start
+        setTimeout(() => {
+          if (!this._scrollArea) return;
+          const { scrollLeft, scrollWidth, clientWidth } = this._scrollArea;
+          const overflows = scrollWidth > clientWidth + 1;
+          // Show both arrows when tabs overflow
+          this._scrollLeftBtn.classList.toggle('visible', overflows);
+          this._scrollRightBtn.classList.toggle('visible', overflows);
+          // Gray out at edges
+          this._scrollLeftBtn.classList.toggle('at-edge', scrollLeft <= 1);
+          this._scrollRightBtn.classList.toggle('at-edge', scrollLeft >= scrollWidth - clientWidth - 1);
+        }, 80);
+      }
+
+      // --- Tab 计数器更新 ---
+      _updateCounter() {
+        if (!this._counterEl) return;
+        this._counterEl.textContent = '(' + this._tabs.length + ')';
+      }
+
+      // --- Toast 提示（短暂显示后自动消失） ---
+      _showToast(msg) {
+        if (!this._toastEl) return;
+        // 清除前一个 toast 定时器
+        if (this._toastTimer) {
+          clearTimeout(this._toastTimer);
+          this._toastTimer = null;
+        }
+        this._toastEl.textContent = msg;
+        this._toastEl.classList.add('ag-toast-visible');
+        this._toastTimer = setTimeout(() => {
+          this._toastEl.classList.remove('ag-toast-visible');
+          this._toastTimer = null;
+        }, 2000);
+      }
+
+      // --- 键盘导航 ---
+      _handleKeydown(e) {
+        // 忽略在输入框中的按键
+        const tag = e.target.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+
+        let direction = 0; // -1=左, 1=右
+        if (e.key === 'ArrowLeft') direction = -1;
+        else if (e.key === 'ArrowRight') direction = 1;
+        else if (e.key === 'Tab') {
+          direction = 1;
+          e.preventDefault(); // 阻止焦点跳出 tab bar
+        }
+        if (direction === 0) return;
+
+        e.preventDefault();
+        const currentIdx = this._tabs.findIndex(t => t.id === this._activeTabId);
+        if (currentIdx === -1) return;
+        const targetIdx = currentIdx + direction;
+        // 不回绕：到达边界时停止
+        if (targetIdx < 0 || targetIdx >= this._tabs.length) return;
+        this._onClickTab(this._tabs[targetIdx].id);
       }
 
       _waitForBridge() {
@@ -2827,19 +3293,44 @@
         const currentId = window._agBridge.getCurrentCascadeId();
         this._log('debug', 'Current cascade ID:', currentId);
 
+        // 清理不属于当前工作区的 stale Tab
+        try {
+          const convos = window._agBridge.findConversationList();
+          const validIds = new Set(convos.map(function(c) { return c.cascadeId; }));
+          const before = this._tabs.length;
+          this._tabs = this._tabs.filter(function(t) {
+            return !t.cascadeId || t.cascadeId === currentId || validIds.has(t.cascadeId);
+          });
+          if (this._tabs.length < before) {
+            this._log('info', 'Cleaned', before - this._tabs.length, 'stale tabs');
+          }
+        } catch (e) {
+          this._log('warn', 'Failed to clean stale tabs:', e.message);
+        }
+
         if (this._tabs.length === 0) {
-          // No persisted tabs - create one for current conversation
-          const title = this._getTitleForCascadeId(currentId) || 'Current Chat';
+          // 无持久化 Tab — 为当前对话创建一个
+          const title = this._getTitleForCascadeId(currentId) || (currentId ? ('Chat ' + currentId.substring(0, 8)) : 'New Chat');
           this._addTabInternal(title, currentId);
+          // 标题可能尚未就绪，1.5s 后重试
+          if (currentId && !this._getTitleForCascadeId(currentId)) {
+            setTimeout(() => this.updateTabTitles(), 1500);
+          }
         } else {
-          // Persisted tabs exist - find or create tab for current conversation
+          // 持久化 Tab 存在 — 查找或创建当前对话的 Tab
           const existingTab = currentId ? this._tabs.find(t => t.cascadeId === currentId) : null;
           if (existingTab) {
             this._activeTabId = existingTab.id;
           } else if (currentId) {
-            // Current conversation not in tabs - add it
-            const title = this._getTitleForCascadeId(currentId) || 'Current Chat';
-            this._addTabInternal(title, currentId);
+            // 当前对话不在 Tab 中 — 添加
+            const title = this._getTitleForCascadeId(currentId) || ('Chat ' + currentId.substring(0, 8));
+            const newTab = this._addTabInternal(title, currentId);
+            if (newTab) {
+              // 标题可能尚未就绪，1.5s 后重试
+              if (!this._getTitleForCascadeId(currentId)) {
+                setTimeout(() => this.updateTabTitles(), 1500);
+              }
+            }
           } else if (this._tabs.length > 0) {
             // No current conversation - activate first tab
             this._activeTabId = this._tabs[0].id;
@@ -2858,10 +3349,37 @@
         this._syncTimer = setInterval(() => {
           if (this._destroyed || !this._bridgeReady || this._state === 'switching') return;
           const currentId = window._agBridge.getCurrentCascadeId();
-          if (!currentId) return;
+          if (!currentId) {
+            this._updateScrollArrows();
+            this.updateTabTitles();
+            this._updateBusyState();
+            return;
+          }
 
           const activeTab = this._tabs.find(t => t.id === this._activeTabId);
-          if (activeTab && activeTab.cascadeId === currentId) return;
+          if (activeTab && activeTab.cascadeId === currentId) {
+            this._updateScrollArrows();
+            this.updateTabTitles();
+            this._updateBusyState();
+            return;
+          }
+
+          // Active tab has no cascadeId (freshly created via "+") — bind it
+          if (activeTab && !activeTab.cascadeId) {
+            activeTab.cascadeId = currentId;
+            const title = this._getTitleForCascadeId(currentId);
+            if (title && !activeTab.customTitle) activeTab.title = title;
+            this._renderTabs();
+            this._saveTabs();
+            this._log('debug', 'Bound cascadeId to active tab:', currentId);
+            // Retry title fetch after a delay (summary may not be available yet)
+            if (!title) {
+              setTimeout(() => this.updateTabTitles(), 2000);
+            }
+            this._updateScrollArrows();
+            this._updateBusyState();
+            return;
+          }
 
           // Current conversation changed externally
           const existingTab = this._tabs.find(t => t.cascadeId === currentId);
@@ -2871,24 +3389,86 @@
             this._saveTabs();
             this._log('debug', 'Synced to externally switched conversation');
           } else {
-            // New conversation opened externally - add tab
+            // 外部打开的新对话（含 Past Conversation 导入）— 添加 Tab
             const title = this._getTitleForCascadeId(currentId) || 'New Chat';
-            this._addTabInternal(title, currentId);
+            const newTab = this._addTabInternal(title, currentId);
+            if (!newTab) {
+              // Tab 已满，拒绝添加（toast 已在 _addTabInternal 中显示）
+              this._log('info', 'Rejected external conversation: tab limit reached');
+              return;
+            }
             this._renderTabs();
             this._saveTabs();
             this._log('debug', 'Added tab for externally opened conversation');
+            // 标题重试：DOM 标题可能需要稍等 React 渲染完成
+            setTimeout(() => this.updateTabTitles(), 800);
+            setTimeout(() => this.updateTabTitles(), 2500);
           }
+          this._updateBusyState();
+          this._updateScrollArrows();
+          this.updateTabTitles();
         }, 3000);
+
+        // Faster polling for busy state (1s) — generation can be brief
+        if (this._busyTimer) clearInterval(this._busyTimer);
+        this._busyTimer = setInterval(() => {
+          if (this._destroyed || !this._bridgeReady) return;
+          this._updateBusyState();
+        }, 1000);
+      }
+
+      _updateBusyState() {
+        if (!window._agBridge || !window._agBridge.getBusyConversations) return;
+        try {
+          const busyIds = window._agBridge.getBusyConversations();
+          let changed = false;
+          for (const tab of this._tabs) {
+            const isBusy = tab.cascadeId ? busyIds.has(tab.cascadeId) : false;
+            const isActive = tab.id === this._activeTabId;
+
+            if (isBusy && !tab.busy) {
+              // Became busy → mark activity unseen (only for non-active tabs)
+              tab.busy = true;
+              if (!isActive) {
+                tab.activityUnseen = true;
+              }
+              console.log('[AG-TabMgr] Tab became busy:', tab.title.substring(0, 20),
+                'cascadeId:', tab.cascadeId ? tab.cascadeId.substring(0, 8) : null,
+                'isActive:', isActive, 'unseen:', tab.activityUnseen);
+              changed = true;
+            } else if (!isBusy && tab.busy) {
+              // No longer busy
+              tab.busy = false;
+              if (isActive) {
+                // Active tab: user is watching, clear unseen
+                tab.activityUnseen = false;
+              } else {
+                // Inactive tab: user wasn't watching, mark unseen
+                tab.activityUnseen = true;
+              }
+              changed = true;
+            }
+
+            // 防护：活跃 Tab 的 activityUnseen 永远不应为 true
+            // 用户已在查看此 Tab，无需提示"有未读活动"
+            if (isActive && tab.activityUnseen) {
+              tab.activityUnseen = false;
+              changed = true;
+            }
+          }
+          if (changed) {
+            this._renderTabs();
+          }
+        } catch (e) {
+          this._log('warn', 'Busy state update failed:', e.message);
+        }
       }
 
       _getTitleForCascadeId(cascadeId) {
         if (!cascadeId || !window._agBridge) return null;
         try {
-          const convos = window._agBridge.findConversationList();
-          const match = convos.find(c => c.cascadeId === cascadeId);
-          if (match && match.summary) {
-            return match.summary.substring(0, 40);
-          }
+          const title = window._agBridge.findConversationTitle(cascadeId);
+          if (title) return title.substring(0, 40);
         } catch (e) {
           this._log('warn', 'Failed to get title:', e.message);
         }
@@ -2898,16 +3478,38 @@
       // --- Persistence ---
       _loadPersistedTabs() {
         try {
-          const raw = localStorage.getItem(TAB_STORAGE_KEY);
+          const storageKey = getTabStorageKey();
+          let raw = localStorage.getItem(storageKey);
+          // 迁移旧 key (ag-better-tab-state → 工作区 key)
+          if (!raw) {
+            raw = localStorage.getItem(TAB_STORAGE_KEY_OLD);
+            if (raw) {
+              localStorage.setItem(storageKey, raw);
+              localStorage.removeItem(TAB_STORAGE_KEY_OLD);
+              this._log('info', 'Migrated tab state from old key');
+            }
+          }
+          // 迁移全局 key (ag-better-tabs → 工作区 key)
+          if (!raw) {
+            raw = localStorage.getItem(TAB_STORAGE_KEY_GLOBAL);
+            if (raw) {
+              localStorage.setItem(storageKey, raw);
+              // 不删除全局 key，其他工作区可能尚未迁移
+              this._log('info', 'Migrated tab state from global key to', storageKey);
+            }
+          }
           if (!raw) return;
           const data = JSON.parse(raw);
           if (data.version !== 1) return;
           this._tabs = (data.tabs || []).map(t => ({
             id: t.id,
-            title: t.title || 'Chat',
+            title: t.title || (t.cascadeId ? ('Chat ' + t.cascadeId.substring(0, 8)) : 'New Chat'),
             cascadeId: t.cascadeId || null,
             timestamp: t.timestamp || Date.now(),
-            stale: false
+            stale: false,
+            customTitle: !!t.customTitle,
+            busy: false,
+            activityUnseen: false
           }));
           this._activeTabId = data.activeTabId || null;
           this._nextId = data.nextId || (this._tabs.length + 1);
@@ -2926,12 +3528,13 @@
               id: t.id,
               title: t.title,
               cascadeId: t.cascadeId,
-              timestamp: t.timestamp
+              timestamp: t.timestamp,
+              customTitle: !!t.customTitle
             })),
             activeTabId: this._activeTabId,
             nextId: this._nextId
           };
-          localStorage.setItem(TAB_STORAGE_KEY, JSON.stringify(data));
+          localStorage.setItem(getTabStorageKey(), JSON.stringify(data));
         } catch (e) {
           this._log('error', 'Failed to save tabs:', e.message);
         }
@@ -2939,22 +3542,22 @@
 
       // --- Tab Operations ---
       _addTabInternal(title, cascadeId) {
-        // Enforce maxTabs - remove oldest if needed
-        while (this._tabs.length >= this._maxTabs) {
-          const oldest = this._tabs[0];
-          if (oldest.id === this._activeTabId && this._tabs.length > 1) {
-            this._tabs.splice(1, 1); // remove second oldest
-          } else {
-            this._tabs.shift();
-          }
+        // 超限时拒绝添加，返回 null
+        if (this._tabs.length >= this._maxTabs) {
+          this._showToast('已达上限（' + this._maxTabs + '），请先关闭标签');
+          this._log('info', 'Tab limit reached, refusing add:', this._maxTabs);
+          return null;
         }
 
         const tab = {
           id: 'tab_' + this._nextId++,
-          title: title || 'New Chat',
+          title: title || (cascadeId ? ('Chat ' + cascadeId.substring(0, 8)) : 'New Chat'),
           cascadeId: cascadeId || null,
           timestamp: Date.now(),
-          stale: false
+          stale: false,
+          customTitle: false,
+          busy: false,
+          activityUnseen: false
         };
         this._tabs.push(tab);
         this._activeTabId = tab.id;
@@ -2964,6 +3567,13 @@
       _onAddTab() {
         if (!this._bridgeReady) {
           this._log('warn', 'Bridge not ready, cannot add tab');
+          return;
+        }
+
+        // 达到上限时显示 toast 提示，不新增 Tab
+        if (this._tabs.length >= this._maxTabs) {
+          this._showToast('已达上限，请先关闭标签');
+          this._log('info', 'Tab limit reached:', this._maxTabs);
           return;
         }
 
@@ -2985,7 +3595,7 @@
           return;
         }
 
-        // Create new tab
+        // 创建新 Tab（cascadeId 会在 sync 中绑定）
         this._addTabInternal('New Chat', null);
         this._renderTabs();
         this._saveTabs();
@@ -3018,9 +3628,20 @@
       }
 
       _onClickTab(tabId) {
-        if (tabId === this._activeTabId) return;
+        if (tabId === this._activeTabId) {
+          // Clicking active tab = "已读", clear unseen
+          const tab = this._tabs.find(t => t.id === tabId);
+          if (tab && tab.activityUnseen) {
+            tab.activityUnseen = false;
+            this._renderTabs();
+          }
+          return;
+        }
         const tab = this._tabs.find(t => t.id === tabId);
         if (!tab) return;
+
+        // Clicking any tab = user is reading it → mark as seen
+        tab.activityUnseen = false;
 
         if (!this._bridgeReady) {
           this._log('warn', 'Bridge not ready');
@@ -3061,6 +3682,7 @@
 
         // Debounce: if another switch happens, this one is cancelled
         setTimeout(() => {
+          if (this._destroyed) return;
           if (this._switchId !== switchId) {
             this._state = 'cancelled';
             this._log('debug', 'Switch cancelled, switchId:', switchId);
@@ -3080,6 +3702,7 @@
 
             // Verify switch after short delay
             setTimeout(() => {
+              if (this._destroyed) return;
               if (this._switchId !== switchId) {
                 this._state = 'cancelled';
                 return;
@@ -3120,6 +3743,43 @@
         }
       }
 
+      // --- Rename ---
+      _startRename(tab, spanEl) {
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.className = 'ag-tab-rename-input';
+        input.value = tab.title;
+        input.style.width = Math.max(spanEl.offsetWidth, 40) + 'px';
+
+        let committed = false;
+        const commit = () => {
+          if (committed) return;
+          committed = true;
+          const val = input.value.trim();
+          if (val && val !== tab.title) {
+            tab.title = val;
+            tab.customTitle = true;
+            this._saveTabs();
+          }
+          this._renderTabs();
+        };
+        const cancel = () => {
+          if (committed) return;
+          committed = true;
+          this._renderTabs();
+        };
+
+        input.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter') { e.preventDefault(); commit(); }
+          if (e.key === 'Escape') { e.preventDefault(); cancel(); }
+        });
+        input.addEventListener('blur', () => commit());
+
+        spanEl.replaceWith(input);
+        input.focus();
+        input.select();
+      }
+
       // --- Rendering ---
       _renderTabs() {
         if (!this._scrollArea) return;
@@ -3130,9 +3790,20 @@
           el.className = 'ag-tab-item' + (tab.id === this._activeTabId ? ' active' : '');
           el.dataset.tabId = tab.id;
           if (tab.stale) el.dataset.stale = 'true';
+          const isActive = tab.busy || tab.activityUnseen;
+          if (isActive) el.dataset.busy = 'true';
+
+          // Status dot (always visible: green=busy/unseen, gray=idle)
+          const dot = document.createElement('span');
+          dot.className = 'ag-tab-dot' + (isActive ? ' active-dot' : '');
+          el.appendChild(dot);
 
           const titleSpan = document.createElement('span');
           titleSpan.textContent = tab.stale ? tab.title + ' [!]' : tab.title;
+          titleSpan.addEventListener('dblclick', (e) => {
+            e.stopPropagation();
+            this._startRename(tab, titleSpan);
+          });
           el.appendChild(titleSpan);
 
           // Close button (only if more than 1 tab)
@@ -3156,19 +3827,22 @@
         if (activeEl) {
           activeEl.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
         }
+        this._updateScrollArrows();
+        this._updateCounter();
       }
 
       // --- Title Updates ---
       updateTabTitles() {
         if (!this._bridgeReady) return;
         try {
-          const convos = window._agBridge.findConversationList();
           let changed = false;
           this._tabs.forEach(tab => {
             if (!tab.cascadeId) return;
-            const match = convos.find(c => c.cascadeId === tab.cascadeId);
-            if (match && match.summary) {
-              const newTitle = match.summary.substring(0, 40);
+            if (tab.customTitle) return;
+            // Use multi-source title lookup
+            const title = window._agBridge.findConversationTitle(tab.cascadeId);
+            if (title) {
+              const newTitle = title.substring(0, 40);
               if (newTitle !== tab.title) {
                 tab.title = newTitle;
                 changed = true;
@@ -3183,6 +3857,23 @@
             this._renderTabs();
             this._saveTabs();
           }
+          // 递进式重试：标题可能需要 AI 回复后才生成，持续重试最多 5 次
+          const hasDefault = this._tabs.some(t => t.cascadeId && !t.customTitle && (t.title === 'New Tab' || t.title === 'Current Chat' || t.title === 'New Chat' || t.title.startsWith('Chat ')));
+          if (hasDefault) {
+            const retryCount = this._titleRetryCount || 0;
+            if (retryCount < 5 && !this._titleRetryTimer) {
+              this._titleRetryCount = retryCount + 1;
+              // 递进延迟: 2s, 3s, 4.5s, 6.75s, 10s
+              const delay = Math.min(2000 * Math.pow(1.5, retryCount), 10000);
+              this._titleRetryTimer = setTimeout(() => {
+                this._titleRetryTimer = null;
+                this.updateTabTitles();
+              }, delay);
+            }
+          } else {
+            // 所有标题已获取，重置重试计数
+            this._titleRetryCount = 0;
+          }
         } catch (e) {
           this._log('warn', 'Title update failed:', e.message);
         }
@@ -3191,10 +3882,11 @@
       // --- Settings Update ---
       setMaxTabs(maxTabs) {
         this._maxTabs = maxTabs;
+        // 超限时移除最早的非活跃 Tab
         while (this._tabs.length > this._maxTabs) {
-          const tab = this._tabs[0];
-          if (tab.id === this._activeTabId && this._tabs.length > 1) {
-            this._tabs.splice(1, 1);
+          const removeIdx = this._tabs.findIndex(t => t.id !== this._activeTabId);
+          if (removeIdx !== -1) {
+            this._tabs.splice(removeIdx, 1);
           } else {
             this._tabs.shift();
           }
@@ -3208,9 +3900,27 @@
         this._destroyed = true;
         if (this._pollTimer) clearTimeout(this._pollTimer);
         if (this._syncTimer) clearInterval(this._syncTimer);
+        if (this._busyTimer) clearInterval(this._busyTimer);
+        if (this._titleRetryTimer) clearTimeout(this._titleRetryTimer);
+        if (this._toastTimer) clearTimeout(this._toastTimer);
+        if (this._resizeHandler) window.removeEventListener('resize', this._resizeHandler);
+        // 移除键盘事件监听
+        if (this._keydownHandler && this._container) {
+          this._container.removeEventListener('keydown', this._keydownHandler);
+        }
         if (this._container && this._container.parentNode) {
           this._container.parentNode.removeChild(this._container);
         }
+        // 移除 toast 元素
+        if (this._toastEl && this._toastEl.parentNode) {
+          this._toastEl.parentNode.removeChild(this._toastEl);
+        }
+        this._container = null;
+        this._scrollArea = null;
+        this._scrollLeftBtn = null;
+        this._scrollRightBtn = null;
+        this._counterEl = null;
+        this._toastEl = null;
         document.body.classList.remove('ag-tab-bar-active');
         this._log('info', 'Tab bar destroyed');
       }
@@ -3228,11 +3938,7 @@
       if (!currentSettings.tabBarEnabled) return;
       _tabManager = new HistoryTabManager(currentSettings.tabBarMaxTabs);
       _tabManager.init();
-
-      // Periodically update tab titles
-      setInterval(() => {
-        if (_tabManager) _tabManager.updateTabTitles();
-      }, 10000);
+      // 标题更新已整合到 3s sync 轮询中，无需独立定时器
     }
 
     function destroyTabBar() {


### PR DESCRIPTION
## Summary

- Horizontal tab bar for parallel conversation management with React Fiber Bridge integration
- Always-visible status dot on each tab (green = busy/unread, gray = idle) using three-layer busy detection
- Workspace-isolated tab storage to prevent cross-project tab leakage in multi-window setups
- Keyboard navigation (ArrowLeft/ArrowRight/Tab), tab counter, and toast notifications
- Settings panel integration: enable/disable toggle and max tabs configuration
- Tab limit enforcement on Past Conversation import (refuse with toast instead of silent eviction)

## Test plan

- [ ] Enable Tab Bar in settings panel, verify tabs appear below input area
- [ ] Create new conversations, verify each gets a tab with auto-fetched title
- [ ] Switch tabs, verify conversation switches correctly
- [ ] Trigger AI generation, verify green dot appears on busy tab
- [ ] Switch away from busy tab, verify green dot persists after generation completes
- [ ] Click the tab to mark as read, verify dot turns gray
- [ ] Open multiple IDE windows with different projects, verify tabs are isolated per workspace
- [ ] Use ArrowLeft/ArrowRight keys to navigate between tabs
- [ ] Fill tabs to max limit, verify toast appears when importing Past Conversation
- [ ] Adjust max tabs in settings, verify limit is respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)