### PR TITLE
fix(workbench): handle plain "Allow" in permission fallback

### DIFF
--- a/app_root/workbench.html
+++ b/app_root/workbench.html
@@ -1087,6 +1087,14 @@
 				await new Promise(r => setTimeout(r, 100));
 			}
 		}
+		if (currentSettings.autoAcceptPatterns['allow'] && (currentSettings.autoAcceptUnlimited || currentSettings.autoAcceptRemaining > 0)) {
+			const allowTarget = findScopedPermissionTarget(scope, 'allow');
+			if (allowTarget) {
+				allowTarget.click();
+				if (scope._abUpdateStats) scope._abUpdateStats({ clicks: 1 });
+				await new Promise(r => setTimeout(r, 100));
+			}
+		}
 	}
 	async function performScopedCommandAutoAccept(scope) {
 		if (!scope || !currentSettings.autoAcceptEnabled) return;


### PR DESCRIPTION
Extend the existing permission auto-accept fallback to handle plain `Allow`.

The current fallback already covers `Allow This Conversation` and `Always Allow`, but some permission prompts now use `Allow` as the visible action.

This keeps the current auto-accept flow unchanged and only adds `Allow` to the existing permission fallback path.