### PR TITLE
feat: 增强 Submit 自动确认，完善问卷弹窗保护与工具权限独立控制

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ You can freely customize this HTML file to build your own features. Following ou
 
 ### Release Timeline (Partial)
 
+- **v0.2.11**: Adds `Submit` auto-accept support with questionnaire modal protection, introduces `Submit`and`Tool Permissions` independent toggle to bypass normal tool permission prompts, and fixes a blind spot in the high-risk command filter for elements within the same container.
 - **v0.2.10**: Fixes the Undo icon rendering issue in conversations by allowing the required Google resources in the Content Security Policy. The fix proposal came from hanliangwei.
 - **v0.2.9**: Fixes accidental auto-clicks on conversation titles when creating a new conversation by skipping title buttons that carry both `title` and `grow`.
 - **v0.2.8**: Fixes the app version string that was still shown as `0.2.2`, and aligns documentation version info.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -8,7 +8,7 @@
     <strong>中文</strong>
   </p>
   <p>
-    <img src="https://img.shields.io/badge/version-0.2.10-brightgreen" alt="Version">
+    <img src="https://img.shields.io/badge/version-0.2.11-brightgreen" alt="Version">
     <img src="https://img.shields.io/badge/dependencies-zero-green" alt="Zero Dependencies">
     <img src="https://img.shields.io/badge/file-single%20HTML-blue" alt="Single File">
     <img src="https://img.shields.io/badge/target-Antigravity-purple" alt="Antigravity">
@@ -52,6 +52,7 @@
 
 ### 版本发布列表（不完全）
 
+- **v0.2.11**：新增 `Submit` 自动点击支持，并增加了问卷弹窗保护；新增 `Submit`、`Tool Permissions` 独立开关，支持一键放行常规工具权限申请；修复了高危命令过滤在同级容器内的检测盲区。
 - **v0.2.10**：修复对话中 Undo 图标未正确渲染的问题，原因是 CSP 未放行所需的 Google 相关资源；本次通过补充相关策略完成修复，方案来自 hanliangwei。
 - **v0.2.9**：修复新建对话时误点历史会话标题的问题；当按钮同时带有 `title` 且包含 `grow` 类名时，跳过自动点击。
 - **v0.2.8**：修复程序内版本号仍显示为 `0.2.2` 的问题，并同步整理文档版本信息。

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -8,7 +8,7 @@
     <strong>中文</strong>
   </p>
   <p>
-    <img src="https://img.shields.io/badge/version-0.2.11-brightgreen" alt="Version">
+    <img src="https://img.shields.io/badge/version-0.2.10-brightgreen" alt="Version">
     <img src="https://img.shields.io/badge/dependencies-zero-green" alt="Zero Dependencies">
     <img src="https://img.shields.io/badge/file-single%20HTML-blue" alt="Single File">
     <img src="https://img.shields.io/badge/target-Antigravity-purple" alt="Antigravity">

--- a/app_root/workbench.html
+++ b/app_root/workbench.html
@@ -1009,17 +1009,17 @@
 		if (text.includes('submit')) {
 			const container = btn.closest('form, [role="dialog"], [class*="modal"]') || btn.parentElement?.parentElement;
 			if (container) {
-				const containerText = container.textContent.toLowerCase();
-				// 如果是权限弹窗（带有 always allow 或 always同意 等字样），判断是否放行
-				if (containerText.includes('always allow') || containerText.includes('allow this conversation') || containerText.includes('always同意')) {
+				const containerHtml = container.innerHTML.toLowerCase();
+				// 如果是权限弹窗，判断是否放行
+				if (containerHtml.includes('always allow') || containerHtml.includes('allow this conversation') || containerHtml.includes('allow running') || containerHtml.includes('allow access')) {
 					if (!currentSettings.autoAcceptPatterns['tool permissions']) {
 						return false; // 如果未勾选 "Tool Permissions"，则依然拦截
 					}
 				} else {
-					// 普通提问框：检查是否有多个选项或 Skip 按钮
-					const hasMultipleOptions = container.querySelectorAll('input[type="radio"], input[type="checkbox"], vscode-radio, vscode-checkbox, [role="radio"], [role="checkbox"]').length > 1;
+					// 调查问卷防呆判定：问卷通常带有 Skip 按钮，或者带有一个文本输入框（用于其它选项）
 					const hasSkipButton = Array.from(container.querySelectorAll('button')).some(b => b.textContent.trim().toLowerCase().includes('skip'));
-					if (hasMultipleOptions || hasSkipButton) {
+					const hasTextInput = container.querySelector('textarea, input[type="text"], vscode-text-field') !== null;
+					if (hasSkipButton || hasTextInput) {
 						return false;
 					}
 				}

--- a/app_root/workbench.html
+++ b/app_root/workbench.html
@@ -444,6 +444,10 @@
 	];
 
 	const AUTO_ACCEPT_CONFIGS = [
+		{ id: 'confirm', label: 'Confirm', defaultEnabled: false },
+		{ id: 'allow', label: 'Allow', defaultEnabled: false },
+		{ id: 'submit', label: 'Submit', defaultEnabled: false },
+		{ id: 'tool permissions', label: 'Tool Permissions', defaultEnabled: false },
 		{ id: 'accept', label: 'Accept', defaultEnabled: false },
 		{ id: 'accept all', label: 'Accept all', defaultEnabled: true },
 		{ id: 'always allow', label: 'Always Allow', defaultEnabled: true },
@@ -1001,12 +1005,36 @@
 		const rejects = ['skip', 'reject', 'cancel', 'close', 'refine', 'dismiss', 'always'];
 		if (rejects.some(r => text.includes(r))) return false;
 		if (!patterns.some(p => text.includes(p))) return false;
+		// 防呆保护：如果在提问框（包含选项和 Skip 按钮）中，放过 submit 按钮，不进行自动点击
+		if (text.includes('submit')) {
+			const container = btn.closest('form, [role="dialog"], [class*="modal"]') || btn.parentElement?.parentElement;
+			if (container) {
+				const containerText = container.textContent.toLowerCase();
+				// 如果是权限弹窗（带有 always allow 或 always同意 等字样），判断是否放行
+				if (containerText.includes('always allow') || containerText.includes('allow this conversation') || containerText.includes('always同意')) {
+					if (!currentSettings.autoAcceptPatterns['tool permissions']) {
+						return false; // 如果未勾选 "Tool Permissions"，则依然拦截
+					}
+				} else {
+					// 普通提问框：检查是否有多个选项或 Skip 按钮
+					const hasMultipleOptions = container.querySelectorAll('input[type="radio"], input[type="checkbox"], vscode-radio, vscode-checkbox, [role="radio"], [role="checkbox"]').length > 1;
+					const hasSkipButton = Array.from(container.querySelectorAll('button')).some(b => b.textContent.trim().toLowerCase().includes('skip'));
+					if (hasMultipleOptions || hasSkipButton) {
+						return false;
+					}
+				}
+			}
+		}
 		const style = window.getComputedStyle(btn); const rect = btn.getBoundingClientRect();
 		return style.display !== 'none' && rect.width > 0 && !btn.disabled;
 	}
 	function findNearbyCommandText(btnEl) {
-		let cmd = ''; let container = btnEl.parentElement; let depth = 0;
+		let cmd = ''; let container = btnEl; let depth = 0;
 		while (container && depth < 10) {
+			// 先检查容器自身以及其内部的代码
+			if (/^(PRE|CODE)$/.test(container.tagName)) cmd += ' ' + container.textContent.trim();
+			container.querySelectorAll('pre, code').forEach(e => cmd += ' ' + e.textContent.trim());
+			
 			let sib = container.previousElementSibling; let sc = 0;
 			while (sib && sc < 5) { if (/^(PRE|CODE)$/.test(sib.tagName)) cmd += ' ' + sib.textContent.trim(); sib.querySelectorAll('pre, code').forEach(e => cmd += ' ' + e.textContent.trim()); sib = sib.previousElementSibling; sc++; }
 			if (cmd.length > 10) break; container = container.parentElement; depth++;

--- a/拦截词.md
+++ b/拦截词.md
@@ -1,0 +1,46 @@
+rm -rf /
+rm -rf ~
+rm -rf *
+format c:
+del /f /s /q
+rmdir /s /q
+:(){:|:&};:
+dd if=
+mkfs.
+> /dev/sda
+chmod -R 777 /
+erase
+rd
+Remove-Item
+Format-Volume
+Clear-Disk
+Remove-Partition
+Initialize-Disk
+Disable-PhysicalDisk
+Stop-Process
+Stop-Computer
+Restart-Computer
+Set-ExecutionPolicy
+Set-MpPreference
+Set-Acl
+Invoke-Expression
+iex
+diskpart
+icacls
+cacls
+takeown
+bcdedit
+vssadmin
+wbadmin
+reg
+cipher
+chown
+shred
+fdisk
+parted
+wmic
+Clear-EventLog
+Remove-EventLog
+Stop-Service
+Disable-NetAdapter
+%0|%0


### PR DESCRIPTION
您好！感谢您对开源社区的辛勤付出！
在antigravity新版本的使用中，我发现现有的自动放行机制需要进行更改。因此，我尝试进行了几项修复和增强，希望能够对大家有所帮助：

**主要变动与优化：**

1.添加了 Submit 自动点击机制，并加入问卷弹窗保护

现已支持对名称为 "Submit" 的常规按钮进行自动确认。针对 ask_question 等交互式调查问卷，为了防止用户的选择权被瞬间跳过，代码增加了严格的保护。现在脚本会通过探测容器内是否存在 Skip 按钮或文本输入框（问卷独有的特征），精准识别出问卷弹窗并主动放弃自动点击，从而避免了“误判拦截”与“强行点击”的问题。


2.新增 Tool Permissions 独立权限控制

在配置菜单中新增了 Tool Permissions 开关。现在，对于常规的工具权限申请（代码通过捕获弹窗 HTML 中是否包含 allow running、always allow 等特征字样来精准识别），如果用户开启了此选项，即可实现一键自动放行，无需再手动确认。


3.修复命令拦截模块的检测盲区

之前的命令过滤逻辑（findNearbyCommandText）只向上遍历了兄弟节点，如果按钮与代码块被包裹在同一个最近父容器内时，可能会导致检测遗漏。
现已修复该问题，改为同时检查所在容器本身的内部代码区块，确保高危指令（如 rm -rf 等）无论层级如何嵌套都能被准确拦截，保障系统安全。


**附加更新**

同步更新了 README.md 与 README_ZH.md 的版本日志。
更新了 README 顶部的版本徽章至 v0.2.11。

这些修改我在本地环境已经经过了初步的测试，自动确认和拦截机制目前都能够按照预期完美协同工作。如果代码中有任何不够严谨或需要改进的地方，烦请各位大佬指出，我会及时进行修改。
再次感谢大家为提升本工具体验所做的贡献！🙏